### PR TITLE
Use #show rules for clarity

### DIFF
--- a/main.typ
+++ b/main.typ
@@ -8,7 +8,7 @@
 // formatting of ``` ... ``` blocks
 #show raw.where(block: true): it => pad(left: 1em, top: 1em, bottom: 1em, it)
 
-#show: doc => acl(doc,
+#show: acl.with(
   anonymous: false,
   title: [Instructions for \*ACL Proceedings],
   authors: (
@@ -51,7 +51,7 @@ You can load tracl into your Typst file as follows:
 ```
 #import "@preview/tracl:0.7.0": *
 
-#show: doc => acl(doc,
+#show: acl.with(
   anonymous: false,
   title: [(your title)],
   authors: (
@@ -167,8 +167,8 @@ Here's some text to illustrate the distance of the list from the subsequent para
 
 == Appendices
 
-Enclose the content of your appendix in the `#appendix` command
-to switch the section numbering over to letters. See @sec:appendix for an example.
+Supply the content of your appendix after the `#show: appendix` command to switch the section numbering over to letters.
+See @sec:appendix for an example.
 
 
 #figure(


### PR DESCRIPTION
This uses the show rule to put everything that follows it into the #appendix command, which might be cleaner when the appendix gets large.

Similarly for the global document we can just use global #show to avoid making a small function.