### PR TITLE
Add hanging indent to bibliography formatting

### DIFF
--- a/acl.typ
+++ b/acl.typ
@@ -252,12 +252,14 @@
 
   let acl-ref = format-reference(..format-reference-arguments)
 
-  set par(hanging-indent: 1em)
-  print-bibliography(
-    format-reference: acl-ref,
-    sorting: "nyt",
-    label-generator: acl-cite.label-generator,
-    )
+  {
+    set par(hanging-indent: 1em)
+    print-bibliography(
+      format-reference: acl-ref,
+      sorting: "nyt",
+      label-generator: acl-cite.label-generator,
+      )
+  }
 }
 
 ////// END PERGAMON CONFIG ///////


### PR DESCRIPTION
The ACL bibliography has a hanging indent which the current style dos not mimic.