### PR TITLE
Remove 'Nimbus Roman No9 L' from tracl-serif

### DIFF
--- a/acl.typ
+++ b/acl.typ
@@ -20,7 +20,7 @@
 
 // "Times" in TeX Live is actually Nimbus Roman.
 // TeX Gyre Termes is builtin in the Typst web app and accepted by aclpubcheck.
-#let tracl-serif = ("TeX Gyre Termes", "Nimbus Roman No9 L", "Libertinus Serif")
+#let tracl-serif = ("TeX Gyre Termes", "Libertinus Serif")
 #let tracl-sans = ("TeX Gyre Heros", "Helvetica")
 #let tracl-mono = ("Inconsolata", "DejaVu Sans Mono")
 


### PR DESCRIPTION
Whenever I use the template in the Typst web app, it complains of missing "Nimbus Roman No9 L". However, it is not actually being used since "TeX Gyre Termes" always exists in the web app.

<img width="568" height="426" alt="image" src="https://github.com/user-attachments/assets/5f7c5178-897d-412f-901b-b2ef0d6ef99f" />

1. Is having `Nimbus Roman No9 L` as a backup truly needed if it's never used? Perhaps only for local reasons?
2. If yes, is there a way to supress warnings to not be distracting?